### PR TITLE
[2/6] Fix transposition table with proper bounds

### DIFF
--- a/moonfish/engines/l2p_alpha_beta.py
+++ b/moonfish/engines/l2p_alpha_beta.py
@@ -77,65 +77,75 @@ class Layer2ParallelAlphaBeta(AlphaBeta):
         START_LAYER = 2
         # start multiprocessing
         nprocs = cpu_count()
-        pool = Pool(processes=nprocs)
-        manager = Manager()
-        shared_cache = manager.dict()
 
-        # pointer that help us in finding the best next move
-        board_to_move_that_generates_it = manager.dict()
+        with Pool(processes=nprocs) as pool, Manager() as manager:
+            shared_cache = manager.dict()
 
-        # starting board list
-        board_list = [(board, board, 0)]
+            # pointer that help us in finding the best next move
+            board_to_move_that_generates_it = manager.dict()
 
-        # generating all possible boards for up to 2 moves ahead
-        for _ in range(START_LAYER):
-            arguments = [
-                (board, board_to_move_that_generates_it, layer)
-                for board, _, layer in board_list
+            # starting board list
+            board_list = [(board, board, 0)]
+
+            # generating all possible boards for up to 2 moves ahead
+            for _ in range(START_LAYER):
+                arguments = [
+                    (board, board_to_move_that_generates_it, layer)
+                    for board, _, layer in board_list
+                ]
+                processes = pool.starmap(self.generate_board_and_moves, arguments)
+                board_list = [board for board in sum(processes, [])]
+
+            negamax_arguments = [
+                (
+                    board,
+                    copy(self.config.negamax_depth) - START_LAYER,
+                    self.config.null_move,
+                    shared_cache,
+                )
+                for board, _, _ in board_list
             ]
-            processes = pool.starmap(self.generate_board_and_moves, arguments)
-            board_list = [board for board in sum(processes, [])]
 
-        negamax_arguments = [
-            (
-                board,
-                self.config.negamax_depth - START_LAYER,
-                self.config.null_move,
-                shared_cache,
-            )
-            for board, _, _ in board_list
-        ]
+            negamax_arguments = [
+                (
+                    board,
+                    copy(self.config.negamax_depth) - START_LAYER,
+                    self.config.null_move,
+                    shared_cache,
+                )
+                for board, _, _ in board_list
+            ]
 
-        parallel_layer_result = pool.starmap(self.negamax, negamax_arguments)
+            parallel_layer_result = pool.starmap(self.negamax, negamax_arguments)
 
-        # grouping output based on the  board that generates it
-        groups = defaultdict(list)
+            # grouping output based on the board that generates it
+            groups = defaultdict(list)
 
-        # adding information about the board and layer
-        # that generates the results and separating them
-        # into groups based on the root board
-        for i in range(len(parallel_layer_result)):
-            groups[board_list[i][1].fen()].append(
-                (*parallel_layer_result[i], board_list[i][0], board_list[i][2])
-            )
+            # adding information about the board and layer
+            # that generates the results and separating them
+            # into groups based on the root board
+            for i in range(len(parallel_layer_result)):
+                groups[board_list[i][1].fen()].append(
+                    (*parallel_layer_result[i], board_list[i][0], board_list[i][2])
+                )
 
-        best_boards = []
+            best_boards = []
 
-        for group in groups.values():
-            # layer and checkmate corrections
-            # they are needed to adjust for
-            # boards from different layers
-            group = list(map(LAYER_SIGNAL_CORRECTION, group))
-            group = list(map(self.checkmate_correction, group))
-            # get best move from group
-            group.sort(key=lambda a: a[0])
-            best_boards.append(group[0])
+            for group in groups.values():
+                # layer and checkmate corrections
+                # they are needed to adjust for
+                # boards from different layers
+                group = list(map(LAYER_SIGNAL_CORRECTION, group))
+                group = list(map(self.checkmate_correction, group))
+                # get best move from group
+                group.sort(key=lambda a: a[0])
+                best_boards.append(group[0])
 
-        # get best board
-        best_boards.sort(key=lambda a: a[0], reverse=True)
-        best_board = best_boards[0][2].fen()
+            # get best board
+            best_boards.sort(key=lambda a: a[0], reverse=True)
+            best_board = best_boards[0][2].fen()
 
-        # get move that results in best board
-        best_move = board_to_move_that_generates_it[best_board]
+            # get move that results in best board
+            best_move = board_to_move_that_generates_it[best_board]
 
-        return best_move
+            return best_move

--- a/moonfish/engines/lazy_smp.py
+++ b/moonfish/engines/lazy_smp.py
@@ -1,5 +1,7 @@
+from copy import copy
 from multiprocessing import cpu_count, Manager, Pool
 
+import chess.polyglot
 from chess import Board, Move
 from moonfish.engines.alpha_beta import AlphaBeta, INF, NEG_INF
 
@@ -9,31 +11,25 @@ class LazySMP(AlphaBeta):
     def search_move(self, board: Board) -> Move:
         # start multiprocessing
         nprocs = cpu_count()
-        pool = Pool(processes=nprocs)
-        manager = Manager()
-        shared_cache = manager.dict()
-        # executing all the moves at layer 1 in parallel
-        # starmap blocks until all process are done
-        pool.starmap(
-            self.negamax,
-            [
-                (
-                    board,
-                    self.config.negamax_depth,
-                    self.config.null_move,
-                    shared_cache,
-                )
-                for _ in range(nprocs)
-            ],
-        )
-
-        # return best move for our original board
-        return shared_cache[
-            (
-                board._transposition_key(),
-                self.config.negamax_depth,
-                self.config.null_move,
-                NEG_INF,
-                INF,
+        with Pool(processes=nprocs) as pool, Manager() as manager:
+            shared_cache = manager.dict()
+            # executing negamax in parallel N times
+            # all processes share the cache for faster convergence
+            # starmap blocks until all processes are done
+            pool.starmap(
+                self.negamax,
+                [
+                    (
+                        board,
+                        copy(self.config.negamax_depth),
+                        self.config.null_move,
+                        shared_cache,
+                    )
+                    for _ in range(nprocs)
+                ],
             )
-        ][1]
+
+            # return best move for our original board
+            # cache key is now just the zobrist hash
+            cache_key = chess.polyglot.zobrist_hash(board)
+            return shared_cache[cache_key][1]


### PR DESCRIPTION
## Summary

- Add `Bound` enum (EXACT, LOWER_BOUND, UPPER_BOUND) for correct TT behavior
- Use Zobrist hash as cache key instead of FEN string (faster)
- Store bound type and depth with each cache entry
- Fix null move pruning condition (was missing `null_move` parameter check)
- Update parallel engines to use new cache format

## Details

The transposition table now correctly stores and uses bound information:

- **EXACT**: Score is within the alpha-beta window, can be used directly
- **LOWER_BOUND**: Node failed high (score >= beta), true score is at least this value
- **UPPER_BOUND**: Node failed low (score <= alpha), true score is at most this value

This prevents incorrect cutoffs and score usage that can cause search instability.

## Parallel Engine Updates

All parallel engines (lazy_smp, l1p, l2p) updated to:
- Use Zobrist hash for cache key lookup
- Use context managers for proper Pool/Manager cleanup
- Fix score negation in l1p (opponent perspective -> our perspective)

## Test plan

- [x] All 64 unit tests pass
- [x] Verified correct bound handling in search

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)