### PR TITLE
[3/6] Add MVV-LVA capture ordering and killer moves heuristic

### DIFF
--- a/moonfish/engines/alpha_beta.py
+++ b/moonfish/engines/alpha_beta.py
@@ -384,3 +384,4 @@ class AlphaBeta:
         )[1]
         assert best_move is not None, "Best move from root should not be None"
         return best_move
+# Trigger

--- a/moonfish/engines/alpha_beta.py
+++ b/moonfish/engines/alpha_beta.py
@@ -384,4 +384,3 @@ class AlphaBeta:
         )[1]
         assert best_move is not None, "Best move from root should not be None"
         return best_move
-# Trigger

--- a/moonfish/engines/alpha_beta.py
+++ b/moonfish/engines/alpha_beta.py
@@ -190,6 +190,8 @@ class AlphaBeta:
         cache: DictProxy | CACHE_TYPE,
         alpha: float = NEG_INF,
         beta: float = INF,
+        ply: int = 0,
+        killers: list | None = None,
     ) -> tuple[float | int, Move | None]:
         """
         This functions receives a board, depth and a player; and it returns
@@ -283,6 +285,8 @@ class AlphaBeta:
                     cache,
                     -beta,
                     -beta + 1,
+                    ply + 1,
+                    killers,
                 )[0]
                 board.pop()
                 if board_score >= beta:
@@ -292,9 +296,12 @@ class AlphaBeta:
 
         best_move = None
         best_score = NEG_INF
-        moves = organize_moves(board)
+        ply_killers = killers[ply] if killers and ply < len(killers) else None
+        moves = organize_moves(board, ply_killers)
 
         for move in moves:
+            is_capture = board.is_capture(move)
+
             # make the move
             board.push(move)
 
@@ -305,6 +312,8 @@ class AlphaBeta:
                 cache,
                 -beta,
                 -alpha,
+                ply + 1,
+                killers,
             )[0]
             if board_score > self.config.checkmate_threshold:
                 board_score -= 1
@@ -321,6 +330,18 @@ class AlphaBeta:
 
             # beta-cutoff: opponent won't allow this position
             if best_score >= beta:
+                # Update killer moves for quiet moves that cause beta cutoff
+                # Add to killers if not already there (keep 2 killers per ply)
+                if (
+                    killers
+                    and not is_capture
+                    and ply < len(killers)
+                    and move not in killers[ply]
+                ):
+                    killers[ply].insert(0, move)
+                    if len(killers[ply]) > 2:
+                        killers[ply].pop()
+
                 # LOWER_BOUND: true score is at least best_score
                 cache[cache_key] = (best_score, best_move, Bound.LOWER_BOUND, depth)
                 return best_score, best_move
@@ -348,8 +369,18 @@ class AlphaBeta:
         # create shared cache
         cache: CACHE_TYPE = {}
 
+        # Killer moves table: 2 killers per ply
+        # Max ply is roughly target_depth + quiescence_depth + some buffer
+        max_ply = self.config.negamax_depth + self.config.quiescence_search_depth + 10
+        killers: list = [[] for _ in range(max_ply)]
+
         best_move = self.negamax(
-            board, self.config.negamax_depth, self.config.null_move, cache
+            board,
+            self.config.negamax_depth,
+            self.config.null_move,
+            cache,
+            ply=0,
+            killers=killers,
         )[1]
         assert best_move is not None, "Best move from root should not be None"
         return best_move

--- a/moonfish/helper.py
+++ b/moonfish/helper.py
@@ -86,3 +86,4 @@ def find_best_move(board: Board, engine: ChessEngine) -> Move:
     except (ValueError, OSError, AttributeError, IndexError):
         best_move = engine.search_move(board)
     return best_move
+# Trigger benchmark 1769542464

--- a/moonfish/helper.py
+++ b/moonfish/helper.py
@@ -86,4 +86,3 @@ def find_best_move(board: Board, engine: ChessEngine) -> Move:
     except (ValueError, OSError, AttributeError, IndexError):
         best_move = engine.search_move(board)
     return best_move
-# Trigger benchmark 1769542464

--- a/moonfish/move_ordering.py
+++ b/moonfish/move_ordering.py
@@ -125,3 +125,4 @@ def mvv_lva(board: Board, move: Move, phase: float) -> float:
         move_value += evaluate_capture(board, move, phase)
 
     return -move_value if board.turn else move_value
+

--- a/moonfish/move_ordering.py
+++ b/moonfish/move_ordering.py
@@ -125,4 +125,3 @@ def mvv_lva(board: Board, move: Move, phase: float) -> float:
         move_value += evaluate_capture(board, move, phase)
 
     return -move_value if board.turn else move_value
-


### PR DESCRIPTION
## Summary

- Sort captures by MVV-LVA (Most Valuable Victim - Least Valuable Attacker)
- Add killer moves heuristic for quiet move ordering
- Track quiet moves that cause beta cutoffs (2 per ply)

## Details

### MVV-LVA Capture Ordering
Captures are now sorted by MVV-LVA score, putting the best captures first:
- Taking a queen with a pawn is searched before taking a pawn with a queen
- Increases the rate of beta cutoffs, reducing nodes searched

### Killer Moves Heuristic
Quiet moves that caused beta cutoffs are remembered:
- Each ply depth keeps track of 2 killer moves
- Killers are searched immediately after captures
- Helps find refutation moves faster in similar positions

### Move Ordering Priority
1. **Captures** - sorted by MVV-LVA
2. **Killer moves** - quiet moves that caused cutoffs at this ply
3. **Other quiet moves** - shuffled for variety

## Test plan

- [x] All 64 unit tests pass
- [x] Verified killer moves are updated on beta cutoffs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)