### PR TITLE
[4/6] Add iterative deepening with aspiration windows and TT move ordering

### DIFF
--- a/moonfish/engines/alpha_beta.py
+++ b/moonfish/engines/alpha_beta.py
@@ -224,12 +224,16 @@ class AlphaBeta:
         """
         original_alpha = alpha
         cache_key = chess.polyglot.zobrist_hash(board)
+        tt_move = None  # Best move from transposition table (for move ordering)
 
         self.nodes += 1
 
         # Check transposition table
         if cache_key in cache:
             cached_score, cached_move, cached_bound, cached_depth = cache[cache_key]
+
+            # Save TT move for ordering even if we can't use the score
+            tt_move = cached_move
 
             # Only use score if cached search was at least as deep as we need
             # Use cached result if:
@@ -299,6 +303,11 @@ class AlphaBeta:
         ply_killers = killers[ply] if killers and ply < len(killers) else None
         moves = organize_moves(board, ply_killers)
 
+        # Put TT move first if available (best move from previous search)
+        if tt_move is not None and tt_move in moves:
+            moves.remove(tt_move)
+            moves.insert(0, tt_move)
+
         for move in moves:
             is_capture = board.is_capture(move)
 
@@ -365,22 +374,87 @@ class AlphaBeta:
         return best_score, best_move
 
     def search_move(self, board: Board) -> Move:
-        self.nodes = 0
-        # create shared cache
-        cache: CACHE_TYPE = {}
+        """
+        Search for the best move using iterative deepening with aspiration windows.
 
-        # Killer moves table: 2 killers per ply
+        Iterative deepening searches depth 1, then 2, then 3, etc.
+        This improves move ordering (TT move from depth N-1 is tried first at depth N)
+        and allows for future time management (can stop early if time runs out).
+
+        Aspiration windows: after depth 1, use a narrow window around the previous
+        score. If the search fails outside the window, re-search with a wider window.
+        """
+        self.nodes = 0
+        # Create shared cache - persists across all depths
+        cache: CACHE_TYPE = {}
+        best_move = None
+        target_depth = self.config.negamax_depth
+        prev_score = None
+
+        # Killer moves table: 2 killers per ply, persists across iterations
         # Max ply is roughly target_depth + quiescence_depth + some buffer
-        max_ply = self.config.negamax_depth + self.config.quiescence_search_depth + 10
+        max_ply = target_depth + self.config.quiescence_search_depth + 10
         killers: list = [[] for _ in range(max_ply)]
 
-        best_move = self.negamax(
-            board,
-            self.config.negamax_depth,
-            self.config.null_move,
-            cache,
-            ply=0,
-            killers=killers,
-        )[1]
+        # Aspiration window parameters
+        INITIAL_WINDOW = 50  # Initial window size (centipawns)
+
+        # Iterative deepening: search depth 1, 2, 3, ... up to target
+        for depth in range(1, target_depth + 1):
+            # Use aspiration windows after first iteration
+            if prev_score is None or depth <= 1:
+                # First iteration: full window
+                alpha = NEG_INF
+                beta = INF
+            else:
+                # Subsequent iterations: narrow window around previous score
+                alpha = prev_score - INITIAL_WINDOW
+                beta = prev_score + INITIAL_WINDOW
+
+            # Aspiration window loop: widen window on fail high/low
+            window = INITIAL_WINDOW
+            while True:
+                score, move = self.negamax(
+                    board,
+                    depth,
+                    self.config.null_move,
+                    cache,
+                    alpha=alpha,
+                    beta=beta,
+                    ply=0,
+                    killers=killers,
+                )
+
+                # Check if we need to re-search with wider window
+                if score <= alpha:
+                    # Failed low: widen window on the low side
+                    window *= 2
+                    # prev_score is guaranteed non-None after depth 1
+                    assert prev_score is not None
+                    alpha = prev_score - window
+                    if window > 500:  # Give up and use full window
+                        alpha = NEG_INF
+                elif score >= beta:
+                    # Failed high: widen window on the high side
+                    window *= 2
+                    # prev_score is guaranteed non-None after depth 1
+                    assert prev_score is not None
+                    beta = prev_score + window
+                    if window > 500:  # Give up and use full window
+                        beta = INF
+                else:
+                    # Score is within window, we're done
+                    break
+
+                # Safety: if window is fully open, we must accept the result
+                if alpha == NEG_INF and beta == INF:
+                    break
+
+            prev_score = score
+
+            # Update best move from completed search
+            if move is not None:
+                best_move = move
+
         assert best_move is not None, "Best move from root should not be None"
         return best_move


### PR DESCRIPTION
## Summary

- Implement iterative deepening (search depth 1, 2, 3, ... N)
- Add aspiration windows for faster searches
- Add TT move ordering (best move from previous search tried first)

## Details

### Iterative Deepening
Instead of searching directly to depth N, we search depth 1, then 2, then 3, etc:

```python
for depth in range(1, target_depth + 1):
    score, move = negamax(board, depth, ...)
```

Benefits:
- TT entries from depth N-1 improve move ordering at depth N
- Enables future time management (stop when time runs out)
- Killer moves accumulate across iterations

### Aspiration Windows
After the first iteration, we use a narrow window around the previous score:

- Initial window: ±50 centipawns
- If search fails high/low, double the window and re-search
- Fall back to full window if window exceeds ±500 cp

This reduces the number of nodes searched when the score is stable.

### TT Move Ordering
- Extract best move from TT lookup even if score can't be used
- Put TT move first in the move list before all other moves
- TT move is the best move found at a shallower depth, excellent for ordering

## Test plan

- [x] All 64 unit tests pass
- [x] Verified iterative deepening visits all depths

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)