### PR TITLE
[5/6] Add Late Move Reductions (LMR) and Principal Variation Search (PVS)

### DIFF
--- a/moonfish/engines/alpha_beta.py
+++ b/moonfish/engines/alpha_beta.py
@@ -308,22 +308,72 @@ class AlphaBeta:
             moves.remove(tt_move)
             moves.insert(0, tt_move)
 
-        for move in moves:
+        in_check = board.is_check()
+
+        for move_index, move in enumerate(moves):
             is_capture = board.is_capture(move)
+            gives_check = board.gives_check(move)
+            is_promotion = move.promotion is not None
 
             # make the move
             board.push(move)
 
-            board_score = -self.negamax(
-                board,
-                depth - 1,
-                null_move,
-                cache,
-                -beta,
-                -alpha,
-                ply + 1,
-                killers,
-            )[0]
+            # Late Move Reductions (LMR):
+            # Reduce search depth for late quiet moves that are unlikely to be good
+            # Conditions: sufficient depth, late move, quiet (no capture/check/promotion)
+            reduction = 0
+            if (
+                depth >= 3
+                and move_index >= 3
+                and not is_capture
+                and not gives_check
+                and not is_promotion
+                and not in_check
+            ):
+                # Simple reduction: reduce by 1 ply
+                reduction = 1
+
+            # Principal Variation Search (PVS):
+            # For the first move, search with full window
+            # For subsequent moves, search with zero window first
+            if move_index == 0:
+                # First move: full window search
+                board_score = -self.negamax(
+                    board,
+                    depth - 1,
+                    null_move,
+                    cache,
+                    -beta,
+                    -alpha,
+                    ply + 1,
+                    killers,
+                )[0]
+            else:
+                # Later moves: zero window search (with LMR reduction if applicable)
+                board_score = -self.negamax(
+                    board,
+                    depth - 1 - reduction,
+                    null_move,
+                    cache,
+                    -alpha - 1,  # Zero window
+                    -alpha,
+                    ply + 1,
+                    killers,
+                )[0]
+
+                # If zero window search found a promising move, re-search with full window
+                if board_score > alpha and (board_score < beta or reduction > 0):
+                    board_score = -self.negamax(
+                        board,
+                        depth - 1,  # Full depth (no reduction)
+                        null_move,
+                        cache,
+                        -beta,
+                        -alpha,
+                        ply + 1,
+                        killers,
+                    )[0]
+
             if board_score > self.config.checkmate_threshold:
                 board_score -= 1
             if board_score < -self.config.checkmate_threshold:


### PR DESCRIPTION
## Summary

- Add Late Move Reductions (LMR) to reduce search depth for late quiet moves
- Add Principal Variation Search (PVS) for faster searches with good move ordering

## Details

### Late Move Reductions (LMR)

Reduce search depth for moves that are unlikely to be the best:

**Conditions:**
- Depth >= 3 (need sufficient depth to reduce)
- Move index >= 3 (first few moves get full depth)
- Not in check (check positions are critical)
- Quiet move (no capture, no check, no promotion)

**Implementation:**
```python
reduction = 1  # Reduce by 1 ply
board_score = negamax(depth - 1 - reduction, ...)
if board_score > alpha:
    board_score = negamax(depth - 1, ...)  # Re-search at full depth
```

### Principal Variation Search (PVS)

Optimize search based on the assumption that the first move is best:

**Implementation:**
- First move: full alpha-beta window search
- Later moves: zero window search first (faster)
- If zero window beats alpha, re-search with full window

```python
if move_index == 0:
    score = negamax(alpha=-beta, beta=-alpha)  # Full window
else:
    score = negamax(alpha=-alpha-1, beta=-alpha)  # Zero window
    if score > alpha:
        score = negamax(alpha=-beta, beta=-alpha)  # Re-search
```

## Test plan

- [x] All 64 unit tests pass
- [x] Verified LMR only applies to late quiet moves
- [x] Verified PVS re-searches when needed

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)